### PR TITLE
Refine job status refetch interval

### DIFF
--- a/src/app/instances/view.tsx
+++ b/src/app/instances/view.tsx
@@ -56,7 +56,7 @@ function InstanceView({
   const report = api.job.report.useQuery(
     { jobId },
     {
-      refetchInterval: 5000,
+      refetchInterval: (q) => q.state.data?.state === "RUNNING" ? 1000 * 60 * 2 : false,
     },
   );
 


### PR DESCRIPTION
This PR intends to resolve #1. I've refined the job status query to periodically refetch the status only if the job is RUNNING. The refetchInterval was set to 2 minutes.
