### PR TITLE
Force signout on missing ssh keys error

### DIFF
--- a/src/app/_hooks/use-keys-error.tsx
+++ b/src/app/_hooks/use-keys-error.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { signOut } from "next-auth/react";
+import { MISSING_SSH_KEYS_ERROR } from "~/lib/constants";
 
 type HookProps = {
   isError: boolean;
@@ -14,7 +15,7 @@ export function useKeysError(props: HookProps) {
   const e = error as Error;
 
   useEffect(() => {
-    if (isError && e.message === "No keys found for user") {
+    if (isError && e.message === MISSING_SSH_KEYS_ERROR) {
       void signOut();
     }
   }, [isError, e]);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -6,3 +6,4 @@ export const jobGPUOptions = process.env.NEXT_PUBLIC_SLURM_GPU_OPTIONS?.split(
 export const maxCPUs = process.env.NEXT_PUBLIC_SLURM_MAX_CPUS
   ? parseInt(process.env.NEXT_PUBLIC_SLURM_MAX_CPUS)
   : 1;
+export const MISSING_SSH_KEYS_ERROR = "No ssh keys found";

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -14,6 +14,7 @@ import { ZodError } from "zod";
 import { getServerAuthSession } from "~/server/auth";
 
 import { getSSHKeys } from "~/server/ssh/utils";
+import { MISSING_SSH_KEYS_ERROR } from "~/lib/constants";
 /**
  * 1. CONTEXT
  *
@@ -122,7 +123,7 @@ export const protectedProcedureWithCredentials = t.procedure.use(
     if (!keys) {
       throw new TRPCError({
         code: "INTERNAL_SERVER_ERROR",
-        message: "No keys found",
+        message: MISSING_SSH_KEYS_ERROR,
       });
     }
     return next({

--- a/src/server/ssh/utils.ts
+++ b/src/server/ssh/utils.ts
@@ -2,6 +2,7 @@ import { promisify } from "util";
 import { ssh } from ".";
 import { env } from "~/env";
 import { exec } from "child_process";
+import { MISSING_SSH_KEYS_ERROR } from "~/lib/constants";
 import fs from "fs/promises";
 
 const createDb = () => {
@@ -80,7 +81,7 @@ export async function copyPublicKeyToServer(
   const publicKey = keys?.publicKey;
 
   if (!publicKey) {
-    throw new Error("No key found for user");
+    throw new Error(MISSING_SSH_KEYS_ERROR);
   }
 
   const connection = await ssh.connect({


### PR DESCRIPTION
This fixes #5. Unified ssh keys error in `MISSING_SSH_KEYS_ERROR` constant and updated its references.
