### PR TITLE
Feat: pending states for cancel and clear actions on the view component

### DIFF
--- a/src/app/instances/logs.tsx
+++ b/src/app/instances/logs.tsx
@@ -8,8 +8,10 @@ import {
 } from "~/app/_components/ui/tabs";
 import { Textarea } from "~/app/_components/ui/textarea";
 import { jobName } from "~/lib/constants";
+import { useEffect } from "react";
 
 export default function LogView({ jobId }: { jobId: string }) {
+  const utils = api.useUtils();
   const stdout = api.ssh.cat.useQuery({
     path: `~/${jobName}-${jobId}.out`,
   });
@@ -17,6 +19,14 @@ export default function LogView({ jobId }: { jobId: string }) {
   const stderr = api.ssh.cat.useQuery({
     path: `~/${jobName}-${jobId}.err`,
   });
+
+  useEffect(() => {
+    if (stdout.data ?? stderr.data) {
+      utils.job.report.invalidate({ jobId }).catch((error) => {
+        console.error("Failed to invalidate report query:", error);
+      });
+    }
+  }, [stdout.data, stderr.data, utils.job.report, jobId]);
 
   return (
     <Tabs defaultValue="stdout">


### PR DESCRIPTION
This PR resolves #9.

- Separate "cancel" (job) and "clear dashboard" buttons to its own components for better maintainability and separation of concerns between components an isolating component only states (i.e. pending and error).
- Change the behavior of clearing the view to route back to "/" instead of showing the new instance form. 
- Show relevant status and error messages on the top of the status panel when instance link is not available (useful when the job is pending or debugging other reason associated with the job status).
- Invalidate status report query when there are changes in the log files so dependent components can update. 
